### PR TITLE
add integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ go:
         - 1.10.x
         - 1.9.x
 
+before_install:
+        - sudo add-apt-repository ppa:duggan/bats --yes
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq bats
+
 before_script:
         - go get github.com/golang/lint/golint
 

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,11 @@ validate: $(GO_SRC)
 	test -z "$$($(GO) vet $$($(GO) list $(PROJECT)/...) 2>&1 | tee /dev/stderr)"
 
 .PHONY: test
-TESTCONTAINER := psgo-test
-test: build
-	$(BUILD_DIR)/$(NAME) > /dev/null
+test: test-integration
 
-	$(BUILD_DIR)/$(NAME) -format "pid,user" > /dev/null
-
-	sudo docker run --name $(TESTCONTAINER) -d alpine sleep 100
-	sudo docker inspect --format '{{.State.Pid}}' $(TESTCONTAINER) | xargs sudo $(BUILD_DIR)/$(NAME) -pid | grep "sleep"
-	sudo docker rm -f $(TESTCONTAINER)
+.PHONY: test-integration
+test-integration:
+	bats test/*.bats
 
 .PHONY: install
 install:

--- a/test/format.bats
+++ b/test/format.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats -t
+
+@test "Default header" {
+	run ./bin/psgo
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "USER" ]]
+	[[ ${lines[0]} =~ "PID" ]]
+	[[ ${lines[0]} =~ "PPID" ]]
+	[[ ${lines[0]} =~ "%CPU" ]]
+	[[ ${lines[0]} =~ "ELAPSED" ]]
+	[[ ${lines[0]} =~ "TTY" ]]
+	[[ ${lines[0]} =~ "TIME" ]]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+}
+
+@test "%CPU header" {
+	run ./bin/psgo -format "%C"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "%CPU" ]]
+
+	run ./bin/psgo -format "pcpu"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "%CPU" ]]
+}
+
+@test "GROUP header" {
+	run ./bin/psgo -format "%G"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "GROUP" ]]
+
+	run ./bin/psgo -format "group"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "GROUP" ]]
+}
+
+@test "PPID header" {
+	run ./bin/psgo -format "%P"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "PPID" ]]
+
+	run ./bin/psgo -format "ppid"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "PPID" ]]
+}
+
+@test "USER header" {
+	run ./bin/psgo -format "%U"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "USER" ]]
+
+	run ./bin/psgo -format "user"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "USER" ]]
+}
+
+@test "COMMAND (args) header" {
+	run ./bin/psgo -format "%a"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+
+	run ./bin/psgo -format "args"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+}
+
+@test "COMMAND (comm) header" {
+	run ./bin/psgo -format "%c"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+
+	run ./bin/psgo -format "comm"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+}
+
+@test "RGROUP header" {
+	run ./bin/psgo -format "%g"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "RGROUP" ]]
+
+	run ./bin/psgo -format "rgroup"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "RGROUP" ]]
+}
+
+@test "NI" {
+	run ./bin/psgo -format "%n"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "NI" ]]
+
+	run ./bin/psgo -format "nice"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "NI" ]]
+}
+
+@test "PID header" {
+	run ./bin/psgo -format "%p"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "PID" ]]
+
+	run ./bin/psgo -format "pid"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "PID" ]]
+}
+
+@test "ELAPSED header" {
+	run ./bin/psgo -format "%t"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "ELAPSED" ]]
+
+	run ./bin/psgo -format "etime"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "ELAPSED" ]]
+}
+
+@test "RUSER header" {
+	run ./bin/psgo -format "%u"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "RUSER" ]]
+
+	run ./bin/psgo -format "ruser"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "RUSER" ]]
+}
+
+@test "TIME header" {
+	run ./bin/psgo -format "%x"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "TIME" ]]
+
+	run ./bin/psgo -format "time"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "TIME" ]]
+}
+
+@test "TTY header" {
+	run ./bin/psgo -format "%y"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "TTY" ]]
+
+	run ./bin/psgo -format "tty"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "TTY" ]]
+}
+
+@test "VSZ header" {
+	run ./bin/psgo -format "%z"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "VSZ" ]]
+
+	run ./bin/psgo -format "vsz"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "VSZ" ]]
+}
+
+@test "ALL header" {
+	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz"
+	[ "$status" -eq 0 ]
+
+	[[ ${lines[0]} =~ "%CPU" ]]
+	[[ ${lines[0]} =~ "GROUP" ]]
+	[[ ${lines[0]} =~ "PPID" ]]
+	[[ ${lines[0]} =~ "USER" ]]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+	[[ ${lines[0]} =~ "COMMAND" ]]
+	[[ ${lines[0]} =~ "RGROUP" ]]
+	[[ ${lines[0]} =~ "NI" ]]
+	[[ ${lines[0]} =~ "PID" ]]
+	[[ ${lines[0]} =~ "ELAPSED" ]]
+	[[ ${lines[0]} =~ "RUSER" ]]
+	[[ ${lines[0]} =~ "TIME" ]]
+	[[ ${lines[0]} =~ "TTY" ]]
+	[[ ${lines[0]} =~ "VSZ" ]]
+}

--- a/test/pid.bats
+++ b/test/pid.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats -t
+
+@test "Join namespace of a Docker container" {
+	ID="$(docker run -d alpine sleep 100)"
+	PID="$(docker inspect --format '{{.State.Pid}}' $ID)"
+
+	run sudo ./bin/psgo -pid $PID
+	[ "$status" -eq 0 ]
+	[[ ${lines[1]} =~ "sleep" ]]
+
+	docker rm -f $ID
+}
+
+@test "Join namespace of a Docker container and format" {
+	ID="$(docker run -d alpine sleep 100)"
+	PID="$(docker inspect --format '{{.State.Pid}}' $ID)"
+
+	run sudo ./bin/psgo -pid $PID -format "pid, args"
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == "PID   COMMAND" ]]
+	[[ ${lines[1]} == "1     sleep 100" ]]
+
+	docker rm -f $ID
+}


### PR DESCRIPTION
Add integration tests to enable a more thorough testing.  All
integration tests are located under ./test and are implemented with
bats.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>