### PR TITLE
support capabilities

### DIFF
--- a/ps/capabilities.go
+++ b/ps/capabilities.go
@@ -1,0 +1,71 @@
+package ps
+
+var (
+	// capabilities are a mapping from a numerical value to the textual
+	// representation of a given capability.  A map allows to easily check
+	// if a given value is included or not.
+	//
+	// NOTE: this map must be maintained and kept in sync with the
+	//       ./include/uapi/linux/capability.h kernel header.
+	capabilities = map[uint]string{
+		0:  "CHOWN",
+		1:  "DAC_OVERRIDE",
+		2:  "DAC_READ_SEARCH",
+		3:  "FOWNER",
+		4:  "FSETID",
+		5:  "KILL",
+		6:  "SETGID",
+		7:  "SETUID",
+		8:  "SETPCAP",
+		9:  "LINUX_IMMUTABLE",
+		10: "NET_BIND_SERVICE",
+		11: "NET_BROADCAST",
+		12: "NET_ADMIN",
+		13: "NET_RAW",
+		14: "IPC_LOCK",
+		15: "IPC_OWNER",
+		16: "SYS_MODULE",
+		17: "SYS_RAWIO",
+		18: "SYS_CHROOT",
+		19: "SYS_PTRACE",
+		20: "SYS_PACCT",
+		21: "SYS_ADMIN",
+		22: "SYS_BOOT",
+		23: "SYS_NICE",
+		24: "SYS_RESOURCE",
+		25: "SYS_TIME",
+		26: "SYS_TTY_CONFIG",
+		27: "MKNOD",
+		28: "LEASE",
+		29: "AUDIT_WRITE",
+		30: "AUDIT_CONTROL",
+		31: "SETFCAP",
+		32: "MAC_OVERRIDE",
+		33: "MAC_ADMIN",
+		34: "SYSLOG",
+		35: "WAKE_ALARM",
+		36: "BLOCK_SUSPEND",
+		37: "AUDIT_READ",
+	}
+	// fullCAPs represents the value of a bitmask with a full capability
+	// set.
+	fullCAPs = uint64(0x3FFFFFFFFF)
+)
+
+// maskToCaps iterates over mask and returns a slice of corresponding
+// capabilities.  If a bit is out of range of known capabilities, it is set as
+// "unknown" to catch potential regressions when new capabilities are added to
+// the kernel.
+func maskToCaps(mask uint64) []string {
+	caps := []string{}
+	for i := uint(0); i < 64; i++ {
+		if (mask>>i)&0x1 == 1 {
+			c, known := capabilities[i]
+			if !known {
+				c = "unknown"
+			}
+			caps = append(caps, c)
+		}
+	}
+	return caps
+}

--- a/test/format.bats
+++ b/test/format.bats
@@ -153,8 +153,35 @@
 	[[ ${lines[0]} =~ "VSZ" ]]
 }
 
+@test "CAPINH header" {
+	run ./bin/psgo -format "capinh"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+}
+
+
+@test "CAPPRM header" {
+	run ./bin/psgo -format "capprm"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+}
+
+
+@test "CAPEFF header" {
+	run ./bin/psgo -format "capeff"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+}
+
+
+@test "CAPBND header" {
+	run ./bin/psgo -format "capbnd"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+}
+
 @test "ALL header" {
-	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz"
+	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd"
 	[ "$status" -eq 0 ]
 
 	[[ ${lines[0]} =~ "%CPU" ]]

--- a/test/pid.bats
+++ b/test/pid.bats
@@ -22,3 +22,15 @@
 
 	docker rm -f $ID
 }
+
+@test "Join namespace of a Docker container and check capabilities" {
+	ID="$(docker run --privileged -d alpine sleep 100)"
+	PID="$(docker inspect --format '{{.State.Pid}}' $ID)"
+
+	run sudo ./bin/psgo -pid $PID -format "pid, capeff"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "PID   CAPABILITIES" ]]
+	[[ ${lines[1]} =~ "1     full" ]]
+
+	docker rm -f $ID
+}


### PR DESCRIPTION
Add four format descriptors (capinh, capprm, capeff, capbnd) to allow
parsing the four sets of capabilities.

Fixes: #11
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>