### PR TITLE
support seccomp

### DIFF
--- a/ps/ps.go
+++ b/ps/ps.go
@@ -146,6 +146,11 @@ var (
 			header: "CAPABILITIES",
 			procFn: processCAPBND,
 		},
+		{
+			normal: "seccomp",
+			header: "SECCOMP",
+			procFn: processSECCOMP,
+		},
 	}
 )
 
@@ -598,4 +603,19 @@ func processCAPEFF(p *process) (string, error) {
 // capability is enabled, "none" is returned.
 func processCAPBND(p *process) (string, error) {
 	return parseCAP(p.pstatus.capBnd)
+}
+
+// processSECCOMP returns the seccomp mode of the process (i.e., disabled,
+// strict or filter) or "?" if /proc/$pid/status.seccomp has a unknown value.
+func processSECCOMP(p *process) (string, error) {
+	switch p.pstatus.seccomp {
+	case "0":
+		return "disabled", nil
+	case "1":
+		return "strict", nil
+	case "2":
+		return "filter", nil
+	default:
+		return "?", nil
+	}
 }

--- a/test/format.bats
+++ b/test/format.bats
@@ -159,13 +159,11 @@
 	[[ ${lines[0]} =~ "CAPABILITIES" ]]
 }
 
-
 @test "CAPPRM header" {
 	run ./bin/psgo -format "capprm"
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "CAPABILITIES" ]]
 }
-
 
 @test "CAPEFF header" {
 	run ./bin/psgo -format "capeff"
@@ -173,15 +171,20 @@
 	[[ ${lines[0]} =~ "CAPABILITIES" ]]
 }
 
-
 @test "CAPBND header" {
 	run ./bin/psgo -format "capbnd"
 	[ "$status" -eq 0 ]
 	[[ ${lines[0]} =~ "CAPABILITIES" ]]
 }
 
+@test "SECCOMP header" {
+	run ./bin/psgo -format "seccomp"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "SECCOMP" ]]
+}
+
 @test "ALL header" {
-	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd"
+	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd, seccomp"
 	[ "$status" -eq 0 ]
 
 	[[ ${lines[0]} =~ "%CPU" ]]
@@ -198,4 +201,5 @@
 	[[ ${lines[0]} =~ "TIME" ]]
 	[[ ${lines[0]} =~ "TTY" ]]
 	[[ ${lines[0]} =~ "VSZ" ]]
+	[[ ${lines[0]} =~ "SECCOMP" ]]
 }

--- a/test/pid.bats
+++ b/test/pid.bats
@@ -34,3 +34,17 @@
 
 	docker rm -f $ID
 }
+
+@test "Join namespace of a Docker container and check seccomp mode" {
+	# Run a privileged container to force seecomp to "disabled" to avoid
+	# hiccups in Travis.
+	ID="$(docker run -d --privileged alpine sleep 100)"
+	PID="$(docker inspect --format '{{.State.Pid}}' $ID)"
+
+	run sudo ./bin/psgo -pid $PID -format "pid, seccomp"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "PID   SECCOMP" ]]
+	[[ ${lines[1]} =~ "1     disabled" ]]
+
+	docker rm -f $ID
+}


### PR DESCRIPTION
Add a `seccomp` format descriptor which prints the seccomp mode of the
corresponding process (i.e., "disabled", "strict" or "fitler").

Fixes: #12
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>