### PR TITLE
list descriptors

### DIFF
--- a/ps/ps.go
+++ b/ps/ps.go
@@ -306,6 +306,15 @@ func processDescriptors(formatDescriptors []aixFormatDescriptor, processes []*pr
 	return data, nil
 }
 
+// ListDescriptors returns a string slice of all supported AIX format
+// descriptors in the normal form.
+func ListDescriptors() (list []string) {
+	for _, d := range descriptors {
+		list = append(list, d.normal)
+	}
+	return
+}
+
 // JoinNamespaceAndProcessInfo has the same semantics as ProcessInfo but joins
 // the mount namespace of the specified pid before extracting data from `/proc`.
 func JoinNamespaceAndProcessInfo(pid, format string) ([]string, error) {

--- a/psgo.go
+++ b/psgo.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/containers/psgo/ps"
@@ -18,8 +19,14 @@ func main() {
 
 	pid := flag.String("pid", "", "join mount namespace of the process ID")
 	format := flag.String("format", "", "ps (1) AIX format comma-separated string")
+	list := flag.Bool("list", false, "list all supported descriptors")
 
 	flag.Parse()
+
+	if *list {
+		fmt.Println(strings.Join(ps.ListDescriptors(), ", "))
+		return
+	}
 
 	if *pid != "" {
 		data, err = ps.JoinNamespaceAndProcessInfo(*pid, *format)

--- a/test/list.bats
+++ b/test/list.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats -t
+
+@test "List descriptors" {
+	run ./bin/psgo -list
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd, seccomp" ]]
+}


### PR DESCRIPTION
Add a new API `ListDescriptors() []string` returning a string slice of
all supported AIX format descriptors in the normal form.  Users of psgo
can use this API to explore supported descriptors (e.g., for the purpose
of bash completion).

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>