### PR TITLE
Don't add a space between caps.

### DIFF
--- a/ps/ps.go
+++ b/ps/ps.go
@@ -596,7 +596,7 @@ func parseCAP(cap string) (string, error) {
 	if len(caps) == 0 {
 		return "none", nil
 	}
-	return strings.Join(caps, ", "), nil
+	return strings.Join(caps, ","), nil
 }
 
 // processCAPINH returns the set of inheritable capabilties associated with


### PR DESCRIPTION
Others might want to parse our ouput with space separation, so remove
spaces between caps, also uses less line space.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>