### PR TITLE
make API slice based

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ The idea behind the library is to provide an easy to use way of extracting proce
 
 This library aims to make things a bit more comfortable, especially for container runtimes, as the API allows to join the mount namespace of a given process and will parse `/proc` and `/dev/` from there. The API consists of the following functions:
 
- - `psgo.ProcessInfo(format string) ([]string, error)`
-   - ProcessInfo returns the process information of all processes in the current mount namespace. The input format must be a comma-separated list of supported AIX format descriptors.  If the input string is empty, the DefaultFormat is used. The return value is a slice of tab-separated strings, to easily use the output for column-based formatting (e.g., with the `text/tabwriter` package).
+ - `psgo.ProcessInfo(descriptors []string) ([][]string, error)`
+   - ProcessInfo returns the process information of all processes in the current mount namespace. The input descriptors must be a slice of supported AIX format descriptors in the normal form or in the code form, if supported.  If the input descriptor slice is empty, the `psgo.DefaultDescriptors` are used. The return value contains the string slice of process data, one per process.
 
- - `psgo.JoinNamespaceAndProcessInfo(pid, format string) ([]string, error)`
+ - `psgo.JoinNamespaceAndProcessInfo(pid string, descriptors []string) ([][]string, error)`
    - JoinNamespaceAndProcessInfo has the same semantics as ProcessInfo but joins the mount namespace of the specified pid before extracting data from /proc.  This way, we can extract the `/proc` data from a container without executing any command inside the container.
 
  - `psgo.ListDescriptors() []string`

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -13,12 +13,13 @@ import (
 
 func main() {
 	var (
-		data []string
-		err  error
+		descriptors []string
+		data        [][]string
+		err         error
 	)
 
 	pid := flag.String("pid", "", "join mount namespace of the process ID")
-	format := flag.String("format", "", "ps (1) AIX format comma-separated string")
+	format := flag.String("format", "", "ps(1) AIX format comma-separated string")
 	list := flag.Bool("list", false, "list all supported descriptors")
 
 	flag.Parse()
@@ -28,13 +29,17 @@ func main() {
 		return
 	}
 
+	if *format != "" {
+		descriptors = strings.Split(*format, ",")
+	}
+
 	if *pid != "" {
-		data, err = psgo.JoinNamespaceAndProcessInfo(*pid, *format)
+		data, err = psgo.JoinNamespaceAndProcessInfo(*pid, descriptors)
 		if err != nil {
 			logrus.Panic(err)
 		}
 	} else {
-		data, err = psgo.ProcessInfo(*format)
+		data, err = psgo.ProcessInfo(descriptors)
 		if err != nil {
 			logrus.Panic(err)
 		}
@@ -42,7 +47,7 @@ func main() {
 
 	tw := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
 	for _, d := range data {
-		fmt.Fprintln(tw, d)
+		fmt.Fprintln(tw, strings.Join(d, "\t"))
 	}
 	tw.Flush()
 }


### PR DESCRIPTION
Change the API arguments from `string` to `[]string` and the return
values from `[]string` to `[][]string` to give users more control over
the data.  This way, users can, for instance, apply filters on the
processes' data.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>