### PR TITLE
Add process state format descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The ps library is compatible with all AIX format descriptors of the ps command-l
   - Current security attributes of the process.
 - **seccomp**
   - Seccomp mode of the process (i.e., disabled, strict or filter). See seccomp(2) for more information.
+- **state**
+  - Process state codes (e.g, **R** for *running*, **S** for *sleeping*). See proc(5) for more information.
 
 We can try out different format descriptors with the psgo binary:
 

--- a/psgo.go
+++ b/psgo.go
@@ -231,6 +231,11 @@ var (
 			onHost: true,
 			procFn: processHGROUP,
 		},
+		{
+			normal: "state",
+			header: "STATE",
+			procFn: processState,
+		},
 	}
 )
 
@@ -628,4 +633,9 @@ func processHGROUP(p *process.Process) (string, error) {
 		return hp.Hgroup, nil
 	}
 	return "?", nil
+}
+
+// processState returns the process state of process p.
+func processState(p *process.Process) (string, error) {
+	return p.Status.State, nil
 }

--- a/test/format.bats
+++ b/test/format.bats
@@ -225,8 +225,14 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "LABEL" ]]
 }
 
+@test "STATE header" {
+	run ./bin/psgo -format "state"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "STATE" ]]
+}
+
 @test "ALL header" {
-	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup"
+	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup, state"
 	[ "$status" -eq 0 ]
 
 	[[ ${lines[0]} =~ "%CPU" ]]
@@ -247,4 +253,5 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "HPID" ]]
 	[[ ${lines[0]} =~ "HUSER" ]]
 	[[ ${lines[0]} =~ "HGROUP" ]]
+	[[ ${lines[0]} =~ "STATE" ]]
 }

--- a/test/list.bats
+++ b/test/list.bats
@@ -3,5 +3,5 @@
 @test "List descriptors" {
 	run ./bin/psgo -list
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "args, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, time, tty, user, vsz" ]]
+	[[ ${lines[0]} =~ "args, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, state, time, tty, user, vsz" ]]
 }

--- a/test/pid.bats
+++ b/test/pid.bats
@@ -84,3 +84,15 @@
 
 	docker rm -f $ID
 }
+
+@test "Join namespace of a Docker container and check the process state" {
+	ID="$(docker run -d alpine sleep 100)"
+	PID="$(docker inspect --format '{{.State.Pid}}' $ID)"
+
+	run sudo ./bin/psgo -pid $PID -format "pid, state"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} == "PID   STATE" ]]
+	[[ ${lines[1]} =~ "1     S" ]]
+
+	docker rm -f $ID
+}


### PR DESCRIPTION
This is needed to mimic `ps -ex` output.

Signed-off-by: Marco Vedovati <mvedovati@suse.com>