### PR TITLE
fix golint error

### DIFF
--- a/internal/proc/status.go
+++ b/internal/proc/status.go
@@ -183,7 +183,7 @@ func ParseStatus(pid string) (*Status, error) {
 	}
 
 	s := Status{}
-	errUnexpectedInput := errors.New(fmt.Sprintf("unexpected input from %s", path))
+	errUnexpectedInput := fmt.Errorf("unexpected input from %s", path)
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {


### PR DESCRIPTION
"should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)"

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>