### PR TITLE
Capabilities: add ambient descriptor + unambiguos headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ root   1     0      0.000   17.249905587s   ?     0s     sleep
 ### Format descriptors
 The ps library is compatible with all AIX format descriptors of the ps command-line utility (see `man 1 ps` for details) but it also supports some additional descriptors that can be useful when seeking specific process-related information.
 
+- **capamb**
+  - Set of ambient capabilities. See capabilities(7) for more information.
 - **capbnd**
   - Set of bounding capabilities. See capabilities(7) for more information.
 - **capeff**

--- a/psgo.go
+++ b/psgo.go
@@ -183,23 +183,28 @@ var (
 			procFn: processVSZ,
 		},
 		{
+			normal: "capamb",
+			header: "CAPAMBIENT",
+			procFn: processCAPAMB,
+		},
+		{
 			normal: "capinh",
-			header: "CAPABILITIES",
+			header: "CAPINHERITED",
 			procFn: processCAPINH,
 		},
 		{
 			normal: "capprm",
-			header: "CAPABILITIES",
+			header: "CAPPERMITTED",
 			procFn: processCAPPRM,
 		},
 		{
 			normal: "capeff",
-			header: "CAPABILITIES",
+			header: "CAPEFFECTIVE",
 			procFn: processCAPEFF,
 		},
 		{
 			normal: "capbnd",
-			header: "CAPABILITIES",
+			header: "CAPBOUNDING",
 			procFn: processCAPBND,
 		},
 		{
@@ -555,6 +560,13 @@ func parseCAP(cap string) (string, error) {
 	}
 	sort.Strings(caps)
 	return strings.Join(caps, ","), nil
+}
+
+// processCAPAMB returns the set of ambient capabilties associated with
+// process p.  If all capabilties are set, "full" is returned.  If no
+// capability is enabled, "none" is returned.
+func processCAPAMB(p *process.Process) (string, error) {
+	return parseCAP(p.Status.CapAmb)
 }
 
 // processCAPINH returns the set of inheritable capabilties associated with

--- a/test/format.bats
+++ b/test/format.bats
@@ -153,28 +153,34 @@
 	[[ ${lines[0]} =~ "VSZ" ]]
 }
 
+@test "CAPAMB header" {
+	run ./bin/psgo -format "capamb"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "CAPAMBIENT" ]]
+}
+
 @test "CAPINH header" {
 	run ./bin/psgo -format "capinh"
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+	[[ ${lines[0]} =~ "CAPINHERITED" ]]
 }
 
 @test "CAPPRM header" {
 	run ./bin/psgo -format "capprm"
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+	[[ ${lines[0]} =~ "CAPPERMITTED" ]]
 }
 
 @test "CAPEFF header" {
 	run ./bin/psgo -format "capeff"
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+	[[ ${lines[0]} =~ "CAPEFFECTIVE" ]]
 }
 
 @test "CAPBND header" {
 	run ./bin/psgo -format "capbnd"
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "CAPABILITIES" ]]
+	[[ ${lines[0]} =~ "CAPBOUNDING" ]]
 }
 
 @test "SECCOMP header" {
@@ -232,7 +238,7 @@ function is_labeling_enabled() {
 }
 
 @test "ALL header" {
-	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup, state"
+	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capamb, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup, state"
 	[ "$status" -eq 0 ]
 
 	[[ ${lines[0]} =~ "%CPU" ]]
@@ -249,6 +255,11 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "TIME" ]]
 	[[ ${lines[0]} =~ "TTY" ]]
 	[[ ${lines[0]} =~ "VSZ" ]]
+	[[ ${lines[0]} =~ "CAPAMBIENT" ]]
+	[[ ${lines[0]} =~ "CAPINHERITED" ]]
+	[[ ${lines[0]} =~ "CAPPERMITTED" ]]
+	[[ ${lines[0]} =~ "CAPEFFECTIVE" ]]
+	[[ ${lines[0]} =~ "CAPBOUNDING" ]]
 	[[ ${lines[0]} =~ "SECCOMP" ]]
 	[[ ${lines[0]} =~ "HPID" ]]
 	[[ ${lines[0]} =~ "HUSER" ]]

--- a/test/list.bats
+++ b/test/list.bats
@@ -3,5 +3,5 @@
 @test "List descriptors" {
 	run ./bin/psgo -list
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "args, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, state, time, tty, user, vsz" ]]
+	[[ ${lines[0]} =~ "args, capamb, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, state, time, tty, user, vsz" ]]
 }

--- a/test/pid.bats
+++ b/test/pid.bats
@@ -29,7 +29,7 @@
 
 	run sudo ./bin/psgo -pid $PID -format "pid, capeff"
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} == "PID   CAPABILITIES" ]]
+	[[ ${lines[0]} == "PID   CAPEFFECTIVE" ]]
 	[[ ${lines[1]} =~ "1     full" ]]
 
 	docker rm -f $ID


### PR DESCRIPTION
- Add the ambient capabilities descriptor
- Rename capabilities headers from "CAPABILITIES" to a unambiguos name (CAPEFFECTIVE, CAPPERMITTED, CAPBOUNDING, CAPINHERITHED, CAPAMBIENT).

Updated tests and docs as well.