### PR TITLE
support user namespaces

### DIFF
--- a/internal/proc/ns.go
+++ b/internal/proc/ns.go
@@ -13,3 +13,12 @@ func ParsePIDNamespace(pid string) (string, error) {
 	}
 	return pidNS, nil
 }
+
+// ParseUserNamespace returns the content of /proc/$pid/ns/user.
+func ParseUserNamespace(pid string) (string, error) {
+	userNS, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/user", pid))
+	if err != nil {
+		return "", err
+	}
+	return userNS, nil
+}

--- a/internal/proc/ns_test.go
+++ b/internal/proc/ns_test.go
@@ -12,3 +12,10 @@ func TestParsePIDNamespace(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, len(pidNS) > 0)
 }
+
+func TestParseUserNamespace(t *testing.T) {
+	// no thorough test but it makes sure things are working
+	userNS, err := ParseUserNamespace("self")
+	assert.Nil(t, err)
+	assert.True(t, len(userNS) > 0)
+}

--- a/internal/proc/status.go
+++ b/internal/proc/status.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
+	"github.com/containers/psgo/internal/types"
 	"github.com/pkg/errors"
 )
 
@@ -160,8 +162,24 @@ type Status struct {
 	NonvoluntaryCtxtSwitches string
 }
 
-// readStatus is used for mocking in unit tests.
-var readStatus = func(path string) ([]string, error) {
+// readStatusUserNS joins the user namespace of pid and returns the content of
+// /proc/pid/status as a string slice.
+func readStatusUserNS(pid string) ([]string, error) {
+	path := fmt.Sprintf("/proc/%s/status", pid)
+	args := []string{"nsenter", "-U", "-t", pid, "cat", path}
+
+	c := exec.Command(args[0], args[1:]...)
+	output, err := c.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error executing %q: %v", strings.Join(args, " "), err)
+	}
+
+	return strings.Split(string(output), "\n"), nil
+}
+
+// readStatusDefault returns the content of /proc/pid/status as a string slice.
+func readStatusDefault(pid string) ([]string, error) {
+	path := fmt.Sprintf("/proc/%s/status", pid)
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -175,15 +193,26 @@ var readStatus = func(path string) ([]string, error) {
 }
 
 // ParseStatus parses the /proc/$pid/status file and returns a *Status.
-func ParseStatus(pid string) (*Status, error) {
-	path := fmt.Sprintf("/proc/%s/status", pid)
-	lines, err := readStatus(path)
+func ParseStatus(ctx *types.PsContext, pid string) (*Status, error) {
+	var lines []string
+	var err error
+
+	if ctx.JoinUserNS {
+		lines, err = readStatusUserNS(pid)
+	} else {
+		lines, err = readStatusDefault(pid)
+	}
+
 	if err != nil {
 		return nil, err
 	}
+	return parseStatus(pid, lines)
+}
 
+// parseStatus extracts data from lines and returns a *Status.
+func parseStatus(pid string, lines []string) (*Status, error) {
 	s := Status{}
-	errUnexpectedInput := fmt.Errorf("unexpected input from %s", path)
+	errUnexpectedInput := fmt.Errorf("unexpected input from /proc/%s/status", pid)
 	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {

--- a/internal/proc/status_test.go
+++ b/internal/proc/status_test.go
@@ -64,14 +64,8 @@ voluntary_ctxt_switches:        150
 nonvoluntary_ctxt_switches:     545
 `
 
-func testReadStatus(_ string) ([]string, error) {
-	return strings.Split(statusFile, "\n"), nil
-}
-
 func TestParseStatus(t *testing.T) {
-	readStatus = testReadStatus
-
-	s, err := ParseStatus("")
+	s, err := parseStatus("testpid", strings.Split(statusFile, "\n"))
 
 	assert.Nil(t, err)
 	assert.NotNil(t, s)

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -3,12 +3,13 @@ package process
 import (
 	"testing"
 
+	"github.com/containers/psgo/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAll(t *testing.T) {
 	// no thorough test but it makes sure things are working
-	p, err := New("self")
+	p, err := New(&types.PsContext{}, "self")
 	assert.Nil(t, err)
 
 	assert.NotNil(t, p.Stat)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,8 @@
+package types
+
+// PsContext controls some internals of the psgo library.
+type PsContext struct {
+	// JoinUserNS will force /proc and /dev parsing from within each PIDs
+	// user namespace.
+	JoinUserNS bool
+}


### PR DESCRIPTION
When a given PID is in a different user namespace, extract
/proc/$pid/status from that namespace to return the correct
user and group of the corresponding processes.

Fixes: #35
Signed-off-by: Valentin Rothberg <vrothberg@suse.com>