### PR TITLE
Add ProcessInfoByPids API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_DIR := ./bin
 BIN_DIR := /usr/local/bin
 NAME := psgo
 PROJECT := github.com/containers/psgo
-
+BATS_TESTS := *.bats
 GO_SRC=$(shell find . -name \*.go)
 
 all: validate build
@@ -37,7 +37,7 @@ test: test-unit test-integration
 
 .PHONY: test-integration
 test-integration:
-	bats test/*.bats
+	bats test/$(BATS_TESTS)
 
 .PHONY: test-unit
 test-unit:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This library aims to make things a bit more comfortable, especially for containe
  - `psgo.ProcessInfo(descriptors []string) ([][]string, error)`
    - ProcessInfo returns the process information of all processes in the current mount namespace. The input descriptors must be a slice of supported AIX format descriptors in the normal form or in the code form, if supported.  If the input descriptor slice is empty, the `psgo.DefaultDescriptors` are used. The return value contains the string slice of process data, one per process.
 
+ - `psgo.ProcessInfoByPids(pids []string, descriptors []string) ([][]string, error)`
+   - ProcessInfoByPids is similar to `psgo.ProcessInfo`, but limits the return value to a list of specified pids. The pids input must be a slice of PIDs for which process information should be returned. If the input descriptor slice is empty, only the format descriptor headers are returned.
+
  - `psgo.JoinNamespaceAndProcessInfo(pid string, descriptors []string) ([][]string, error)`
    - JoinNamespaceAndProcessInfo has the same semantics as ProcessInfo but joins the mount namespace of the specified pid before extracting data from /proc.  This way, we can extract the `/proc` data from a container without executing any command inside the container.
 
@@ -26,6 +29,17 @@ root         1       0       0.064    6h3m27.677997443s    ?        13.98s      
 root         2       0       0.000    6h3m27.678380128s    ?        20ms        [kthreadd]
 root         4       2       0.000    6h3m27.678701852s    ?        0s          [kworker/0:0H]
 root         6       2       0.000    6h3m27.678999508s    ?        0s          [mm_percpu_wq]
+```
+
+### Listing processes
+You can use the `--pids` flag to restrict `psgo` output to a subset of processes. This option accepts a list of comma separate process IDs and will return exactly the same kind of information per process as the default output.
+
+```
+$ ./bin/psgo --pids 1,$(pgrep bash | tr "\n" ",")
+USER   PID     PPID    %CPU    ELAPSED                TTY     TIME   COMMAND 
+root   1       0       0.009   128h52m44.193475932s   ?       40s    systemd
+root   20830   20827   0.000   105h2m44.19579679s     pts/5   0s     bash
+root   25843   25840   0.000   102h56m4.196072027s    pts/6   0s     bash
 ```
 
 ### Listing processes within a container

--- a/psgo.go
+++ b/psgo.go
@@ -341,12 +341,18 @@ func JoinNamespaceAndProcessInfo(pid string, descriptors []string) ([][]string, 
 // The return value is an array of tab-separated strings, to easily use the
 // output for column-based formatting (e.g., with the `text/tabwriter` package).
 func ProcessInfo(descriptors []string) ([][]string, error) {
-	aixDescriptors, err := translateDescriptors(descriptors)
+	pids, err := proc.GetPIDs()
 	if err != nil {
 		return nil, err
 	}
 
-	pids, err := proc.GetPIDs()
+	return ProcessInfoByPids(pids, descriptors)
+}
+
+// ProcessInfoByPids is like ProcessInfo, but the process information returned
+// is limited to a list of user specified PIDs.
+func ProcessInfoByPids(pids []string, descriptors []string) ([][]string, error) {
+	aixDescriptors, err := translateDescriptors(descriptors)
 	if err != nil {
 		return nil, err
 	}

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -14,11 +14,13 @@ import (
 func main() {
 	var (
 		descriptors []string
+		pidsList    []string
 		data        [][]string
 		err         error
 	)
 
 	pid := flag.String("pid", "", "join mount namespace of the process ID")
+	pids := flag.String("pids", "", "comma separated list of process IDs to retrieve")
 	format := flag.String("format", "", "ps(1) AIX format comma-separated string")
 	list := flag.Bool("list", false, "list all supported descriptors")
 
@@ -33,8 +35,22 @@ func main() {
 		descriptors = strings.Split(*format, ",")
 	}
 
+	if *pid != "" && *pids != "" {
+		logrus.Error("you can't pass both --pid and --pids options")
+		os.Exit(-1)
+	}
+
+	if *pids != "" {
+		pidsList = strings.Split(*pids, ",")
+	}
+
 	if *pid != "" {
 		data, err = psgo.JoinNamespaceAndProcessInfo(*pid, descriptors)
+		if err != nil {
+			logrus.Panic(err)
+		}
+	} else if len(pidsList) > 0 {
+		data, err = psgo.ProcessInfoByPids(pidsList, descriptors)
 		if err != nil {
 			logrus.Panic(err)
 		}

--- a/test/pids.bats
+++ b/test/pids.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats -t
+
+@test "Get process information of one process only (init)" {
+	pid="1"
+	run ./bin/psgo -pids "$pid" -format "user,pid,ppid"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ^USER\ +PID\ +PPID$ ]]
+	[[ ${lines[1]} =~ ^root\ +$pid\ +0$ ]]
+}
+
+@test "Get process information of a set of running containers" {
+	nCtrs=5
+	pidsList=()
+	ctridList=()
+	for (( i=1; i<=$nCtrs; i++ )); do
+		ctridList[$i]="$(docker run -d busybox sleep 60)"
+		pidsList[$i]="$(docker inspect --format '{{.State.Pid}}' ${ctridList[$i]})"
+	done
+
+	pids="$(tr ' ' ',' <<< ${pidsList[@]})"
+
+	run ./bin/psgo -pids "$pids" -format "pid,comm"
+
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ^PID\ +COMMAND$ ]]
+	for (( i=1; i<=$nCtrs; i++ )); do
+		[[ ${lines[$i]} =~ ^${pidsList[$i]}\ +sleep$ ]]
+	    docker rm -f ${ctridList[$i]}
+	done
+}
+
+@test "Return error on both --pid and --pids options" {
+	run ./bin/psgo -pid 1 --pids 1,2,3
+	! [ "$status" -eq  0]
+}
+
+@test "Proccess information with --pids vs all processes" {
+	nCtrs=5
+	pidsList=()
+	ctridList=()
+	for (( i=1; i<=$nCtrs; i++ )); do
+		ctridList[$i]="$(docker run -d busybox sleep 60)"
+		pidsList[$i]="$(docker inspect --format '{{.State.Pid}}' ${ctridList[$i]})"
+	done
+
+	pids="$(tr ' ' ',' <<< ${pidsList[@]})"
+
+	run ./bin/psgo --pids "$pids" -format "user,group,pid,ppid,tty,nice,capeff"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ^USER\ +GROUP\ +PID\ +PPID\ +TTY\ +NI\ +EFFECTIVE\ CAPS$ ]]
+	pidsLines=${lines[@]}
+
+	run ./bin/psgo -format "user,group,pid,ppid,tty,nice,capeff"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ ^USER\ +GROUP\ +PID\ +PPID\ +TTY\ +NI\ +EFFECTIVE\ CAPS$ ]]
+
+	for (( i=1; i<=$nCtrs; i++ )); do
+	    docker rm -f ${ctridList[$i]}
+	done
+}


### PR DESCRIPTION
ProcessInfoByPids API is used to to retrieve process information from a list of user specified processes. 

The sample application has been updated to use it as an option.

Implements #32