### PR TITLE
Fix race condition on processes dieing

### DIFF
--- a/psgo.go
+++ b/psgo.go
@@ -363,7 +363,7 @@ func JoinNamespaceAndProcessInfoByPids(pids []string, descriptors []string) ([][
 	for _, pid := range pids {
 		ns, err := proc.ParsePIDNamespace(pid)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if os.IsNotExist(errors.Cause(err)) {
 				// catch race conditions
 				continue
 			}
@@ -378,6 +378,10 @@ func JoinNamespaceAndProcessInfoByPids(pids []string, descriptors []string) ([][
 	data := [][]string{}
 	for i, pid := range pidList {
 		pidData, err := JoinNamespaceAndProcessInfo(pid, descriptors)
+		if os.IsNotExist(errors.Cause(err)) {
+			// catch race conditions
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Some times process will exit before we can read
their data.  We should ignore these processes if
they get ENOENT.  Also we need to unwrap errors
to make sure we check against unwrapped errors.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>