### PR TITLE
Fix another race-condition when a PID has died

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -108,7 +108,7 @@ func FromPIDs(ctx *types.PsContext, pids []string) ([]*Process, error) {
 	for _, pid := range pids {
 		p, err := New(ctx, pid)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if os.IsNotExist(errors.Cause(err)) {
 				// proc parsing is racy
 				// Let's ignore "does not exist" errors
 				continue


### PR DESCRIPTION
Use errors.Cause(...) to unwrap the error and examine the cause.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>