### PR TITLE
switch to golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_install:
         - sudo apt-get update -qq
         - sudo apt-get install -qq bats
 
-before_script:
-        - go get -u golang.org/x/lint/golint
-
 script:
         - make validate
         - make build

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ vendor: vendor.conf
 	vndr
 
 .PHONY: validate
-validate: $(GO_SRC)
+validate: .install.lint
 	@which gofmt >/dev/null 2>/dev/null || (echo "ERROR: gofmt not found." && false)
 	test -z "$$(gofmt -s -l . | grep -vE 'vendor/' | tee /dev/stderr)"
-	@which golint >/dev/null 2>/dev/null|| (echo "ERROR: golint not found." && false)
-	test -z "$$(golint $(PROJECT)/...  | grep -vE 'vendor/' | tee /dev/stderr)"
+	@which golangci-lint >/dev/null 2>/dev/null|| (echo "ERROR: golangci-lint not found." && false)
+	test -z "$$(golangci-lint run)"
 	@go doc cmd/vet >/dev/null 2>/dev/null|| (echo "ERROR: go vet not found." && false)
 	test -z "$$($(GO) vet $$($(GO) list $(PROJECT)/...) 2>&1 | tee /dev/stderr)"
 
@@ -47,6 +47,10 @@ test-unit:
 .PHONY: install
 install:
 	sudo install -D -m755 $(BUILD_DIR)/$(NAME) $(BIN_DIR)
+
+.PHONY: .install.lint
+.install.lint:
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
`make validate` will always fetch the latest version of golangci-lint.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>