### PR TITLE
psgo: add support for running in a namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_install:
         - sudo apt-get install -qq bats
 
 script:
-        - make validate
-        - make build
-        - make test
+        - make validate || travis_terminate 1
+        - make build || travis_terminate 1
+        - make test || travis_terminate 1

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ install:
 
 .PHONY: .install.lint
 .install.lint:
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	# Workaround for https://github.com/golangci/golangci-lint/issues/523
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@master
 
 .PHONY: uninstall
 uninstall:

--- a/internal/proc/ns.go
+++ b/internal/proc/ns.go
@@ -15,9 +15,19 @@
 package proc
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
+
+	"github.com/pkg/errors"
 )
+
+type IDMap struct {
+	ContainerID int
+	HostID      int
+	Size        int
+}
 
 // ParsePIDNamespace returns the content of /proc/$pid/ns/pid.
 func ParsePIDNamespace(pid string) (string, error) {
@@ -35,4 +45,35 @@ func ParseUserNamespace(pid string) (string, error) {
 		return "", err
 	}
 	return userNS, nil
+}
+
+// ReadMappings reads the user namespace mappings at the specified path
+func ReadMappings(path string) ([]IDMap, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open %s", path)
+	}
+	defer file.Close()
+
+	mappings := []IDMap{}
+
+	buf := bufio.NewReader(file)
+	for {
+		line, _, err := buf.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				return mappings, nil
+			}
+			return nil, errors.Wrapf(err, "cannot read line from %s", path)
+		}
+		if line == nil {
+			return mappings, nil
+		}
+
+		containerID, hostID, size := 0, 0, 0
+		if _, err := fmt.Sscanf(string(line), "%d %d %d", &containerID, &hostID, &size); err != nil {
+			return nil, errors.Wrapf(err, "cannot parse %s", string(line))
+		}
+		mappings = append(mappings, IDMap{ContainerID: containerID, HostID: hostID, Size: size})
+	}
 }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -45,7 +45,7 @@ type Process struct {
 	Hgroup string
 }
 
-// LookupGID returns the textual group ID, if it can be optained, or the
+// LookupGID returns the textual group ID, if it can be obtained, or the
 // decimal representation otherwise.
 func LookupGID(gid string) (string, error) {
 	gidNum, err := strconv.Atoi(gid)
@@ -59,7 +59,7 @@ func LookupGID(gid string) (string, error) {
 	return g.Name, nil
 }
 
-// LookupUID return the textual user ID, if it can be optained, or the decimal
+// LookupUID return the textual user ID, if it can be obtained, or the decimal
 // representation otherwise.
 func LookupUID(uid string) (string, error) {
 	uidNum, err := strconv.Atoi(uid)

--- a/psgo.go
+++ b/psgo.go
@@ -69,7 +69,7 @@ type aixFormatDescriptor struct {
 	// onHost controls if data of the corresponding host processes will be
 	// extracted as well.
 	onHost bool
-	// procFN points to the corresponding method to etract the desired data.
+	// procFN points to the corresponding method to extract the desired data.
 	procFn processFunc
 }
 
@@ -358,7 +358,7 @@ func JoinNamespaceAndProcessInfo(pid string, descriptors []string) ([][]string, 
 
 // JoinNamespaceAndProcessInfoByPids has similar semantics to
 // JoinNamespaceAndProcessInfo and avoids duplicate entries by joining a giving
-// PID namepsace only once.
+// PID namespace only once.
 func JoinNamespaceAndProcessInfoByPids(pids []string, descriptors []string) ([][]string, error) {
 	// Extracting data from processes that share the same PID namespace
 	// would yield duplicate results.  Avoid that by extracting data only


### PR DESCRIPTION
add support for running in a user namespace so that `podman top -l huser` works correctly for rootless containers.

Once this lands, the patch for podman is trivial:

```diff
diff --git a/libpod/container_top_linux.go b/libpod/container_top_linux.go
index 392a7029..0f6706d4 100644
--- a/libpod/container_top_linux.go
+++ b/libpod/container_top_linux.go
@@ -6,6 +6,7 @@ import (
        "strconv"
        "strings"
 
+       "github.com/containers/libpod/pkg/rootless"
        "github.com/containers/psgo"
        "github.com/pkg/errors"
 )
@@ -47,7 +48,14 @@ func (c *Container) GetContainerPidInformation(descriptors []string) ([]string,
        //       filters on the data.  We need to change the API here and the
        //       varlink API to return a [][]string if we want to make use of
        //       filtering.
-       psgoOutput, err := psgo.JoinNamespaceAndProcessInfo(pid, descriptors)
+       opts := psgo.JoinNamespaceOpts{}
+       if rootless.IsRootless() {
+               if err := psgo.SetMappings(&opts, 0); err != nil {
+                       return nil, err
+               }
+       }
+
+       psgoOutput, err := psgo.JoinNamespaceAndProcessInfoWithOptions(pid, descriptors, &opts)
        if err != nil {
                return nil, err
        }
diff --git a/libpod/pod_top_linux.go b/libpod/pod_top_linux.go
index f49e28c9..9064920c 100644
--- a/libpod/pod_top_linux.go
+++ b/libpod/pod_top_linux.go
@@ -6,6 +6,7 @@ import (
        "strconv"
        "strings"
 
+       "github.com/containers/libpod/pkg/rootless"
        "github.com/containers/psgo"
 )
 
@@ -43,7 +44,13 @@ func (p *Pod) GetPodPidInformation(descriptors []string) ([]string, error) {
        //       filters on the data.  We need to change the API here and the
        //       varlink API to return a [][]string if we want to make use of
        //       filtering.
-       output, err := psgo.JoinNamespaceAndProcessInfoByPids(pids, descriptors)
+       opts := psgo.JoinNamespaceOpts{}
+       if rootless.IsRootless() {
+               if err := psgo.SetMappings(&opts, 0); err != nil {
+                       return nil, err
+               }
+       }
+       output, err := psgo.JoinNamespaceAndProcessInfoByPidsWithOptions(pids, descriptors, &opts)
        if err != nil {
                return nil, err
        }
```