### PR TITLE
Makefile: use go proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 export GO111MODULE=off
+export GOPROXY=https://proxy.golang.org
 
 SHELL= /bin/bash
 GO ?= go


### PR DESCRIPTION
Use GOPROXY=https://proxy.golang.org to speed up fetching dependencies.
For details please refer to https://proxy.golang.org/.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>