### PR TITLE
add `stime` descriptor to extract process start times

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The ps library is compatible with all AIX format descriptors of the ps command-l
   - Seccomp mode of the process (i.e., disabled, strict or filter). See seccomp(2) for more information.
 - **state**
   - Process state codes (e.g, **R** for *running*, **S** for *sleeping*). See proc(5) for more information.
+- **stime**
+  - Process start time (e.g, "2019-12-09 10:50:36 +0100 CET).
 
 We can try out different format descriptors with the psgo binary:
 

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -188,23 +188,30 @@ func (p *Process) SetHostData() error {
 
 // ElapsedTime returns the time.Duration since process p was created.
 func (p *Process) ElapsedTime() (time.Duration, error) {
-	sinceBoot, err := strconv.ParseInt(p.Stat.Starttime, 10, 64)
+	startTime, err := p.StartTime()
 	if err != nil {
 		return 0, err
+	}
+	return (time.Now()).Sub(startTime), nil
+}
+
+// StarTime returns the time.Time when process p was started.
+func (p *Process) StartTime() (time.Time, error) {
+	sinceBoot, err := strconv.ParseInt(p.Stat.Starttime, 10, 64)
+	if err != nil {
+		return time.Time{}, err
 	}
 	clockTicks, err := host.ClockTicks()
 	if err != nil {
-		return 0, err
+		return time.Time{}, err
+	}
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return time.Time{}, err
 	}
 
 	sinceBoot = sinceBoot / clockTicks
-
-	bootTime, err := host.BootTime()
-	if err != nil {
-		return 0, err
-	}
-	created := time.Unix(sinceBoot+bootTime, 0)
-	return (time.Now()).Sub(created), nil
+	return time.Unix(sinceBoot+bootTime, 0), nil
 }
 
 // CPUTime returns the cumlative CPU time of process p as a time.Duration.

--- a/psgo.go
+++ b/psgo.go
@@ -310,6 +310,11 @@ var (
 			header: "STATE",
 			procFn: processState,
 		},
+		{
+			normal: "stime",
+			header: "STIME",
+			procFn: processStartTime,
+		},
 	}
 )
 
@@ -713,6 +718,15 @@ func processTIME(p *process.Process, ctx *psContext) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("%v", cpu), nil
+}
+
+// processStartTime returns the start time of process p.
+func processStartTime(p *process.Process, ctx *psContext) (string, error) {
+	sTime, err := p.StartTime()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v", sTime), nil
 }
 
 // processTTY returns the controlling tty (terminal) of process p.

--- a/test/format.bats
+++ b/test/format.bats
@@ -237,6 +237,12 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "STATE" ]]
 }
 
+@test "STIME header" {
+	run ./bin/psgo -format "stime"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "STIME" ]]
+}
+
 @test "ALL header" {
 	run ./bin/psgo -format "pcpu, group, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capamb, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup, state"
 	[ "$status" -eq 0 ]

--- a/test/list.bats
+++ b/test/list.bats
@@ -3,5 +3,5 @@
 @test "List descriptors" {
 	run ./bin/psgo -list
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "args, capamb, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, state, time, tty, user, vsz" ]]
+	[[ ${lines[0]} =~ "args, capamb, capbnd, capeff, capinh, capprm, comm, etime, group, hgroup, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, ruser, seccomp, state, stime, time, tty, user, vsz" ]]
 }


### PR DESCRIPTION
Fixes: #61
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @haircommander @giuseppe PTAL