### PR TITLE
psgo: use Stat.Comm in processCOMM

### DIFF
--- a/psgo.go
+++ b/psgo.go
@@ -663,12 +663,7 @@ func processARGS(p *process.Process, ctx *psContext) (string, error) {
 
 // processCOMM returns the command name (i.e., executable name) of process p.
 func processCOMM(p *process.Process, ctx *psContext) (string, error) {
-	// ps (1) returns "[$name]" if command/args are empty
-	if p.CmdLine[0] == "" {
-		return processName(p, ctx)
-	}
-	spl := strings.Split(p.CmdLine[0], "/")
-	return spl[len(spl)-1], nil
+	return p.Stat.Comm, nil
 }
 
 // processNICE returns the nice value of process p.

--- a/psgo_test.go
+++ b/psgo_test.go
@@ -46,8 +46,8 @@ func TestProcessARGS(t *testing.T) {
 
 func TestProcessCOMM(t *testing.T) {
 	p := process.Process{
-		Status: proc.Status{
-			Name: "foo-bar",
+		Stat: proc.Stat{
+			Comm: "foo-bar",
 		},
 		CmdLine: []string{""},
 	}
@@ -55,9 +55,12 @@ func TestProcessCOMM(t *testing.T) {
 	ctx := new(psContext)
 	comm, err := processCOMM(&p, ctx)
 	assert.Nil(t, err)
-	assert.Equal(t, "[foo-bar]", comm)
+	assert.Equal(t, "foo-bar", comm)
 
 	p = process.Process{
+		Stat: proc.Stat{
+			Comm: "foo-bar",
+		},
 		CmdLine: []string{"/usr/bin/foo-bar"},
 	}
 


### PR DESCRIPTION
This is the field that ps(1) classically uses, also verified against
procps-ng-3.3.15.

Fixes #65.