### PR TITLE
make validate: don't eat golangci reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ ifeq ($(shell go help mod >/dev/null 2>&1 && echo true), true)
 	GO_BUILD=GO111MODULE=on $(GO) build -mod=vendor
 endif
 
+GOBIN ?= $(GO)/bin
+
 all: validate build
 
 .PHONY: build
@@ -34,12 +36,7 @@ vendor:
 
 .PHONY: validate
 validate: .install.lint
-	@which gofmt >/dev/null 2>/dev/null || (echo "ERROR: gofmt not found." && false)
-	test -z "$$(gofmt -s -l . | grep -vE 'vendor/' | tee /dev/stderr)"
-	@which golangci-lint >/dev/null 2>/dev/null|| (echo "ERROR: golangci-lint not found." && false)
-	test -z "$$(golangci-lint run)"
-	@go doc cmd/vet >/dev/null 2>/dev/null|| (echo "ERROR: go vet not found." && false)
-	test -z "$$($(GO) vet $$($(GO) list $(PROJECT)/...) 2>&1 | tee /dev/stderr)"
+	$(GOBIN)/golangci-lint run
 
 .PHONY: test
 test: test-unit test-integration
@@ -59,8 +56,7 @@ install:
 
 .PHONY: .install.lint
 .install.lint:
-	# Workaround for https://github.com/golangci/golangci-lint/issues/523
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	VERSION=1.24.0 GOBIN=$(GOBIN) sh ./hack/install_golangci.sh
 
 .PHONY: uninstall
 uninstall:

--- a/hack/install_golangci.sh
+++ b/hack/install_golangci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+die() { echo "${1:-No error message given} (from $(basename $0))"; exit 1; }
+
+[ -n "$VERSION" ] || die "\$VERSION is empty or undefined"
+[ -n "$GOBIN" ] || die "\$GOBIN is empty or undefined"
+
+BIN="$GOBIN/golangci-lint"
+if [ ! -x "$BIN" ]; then
+    echo "Installing golangci-lint v$VERSION into $GOBIN"
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOBIN v$VERSION
+else
+    # Prints it's own file name as part of --verison output
+    echo "Using existing $(dirname $BIN)/$($BIN --version)"
+fi

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -192,7 +192,7 @@ func (p *Process) ElapsedTime() (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	return (time.Now()).Sub(startTime), nil
+	return time.Since(startTime), nil
 }
 
 // StarTime returns the time.Time when process p was started.


### PR DESCRIPTION
Moreover, we really just need to run `golangci-lint` since it already
includes `gofmt`, `govet` and dozens of other linters.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>