### PR TITLE
Fix build for mips architecture

### DIFF
--- a/internal/dev/tty.go
+++ b/internal/dev/tty.go
@@ -113,8 +113,9 @@ func TTYs() (*[]TTY, error) {
 		}
 		s := fi.Sys().(*syscall.Stat_t)
 		t := TTY{
-			Minor: minDevNum(s.Rdev),
-			Major: majDevNum(s.Rdev),
+			// Rdev is type uint32 on mips arch so we have to cast to uint64
+			Minor: minDevNum(uint64(s.Rdev)),
+			Major: majDevNum(uint64(s.Rdev)),
 			Path:  dev,
 		}
 		ttys = append(ttys, t)


### PR DESCRIPTION
Rdev is uint32 on mips so we have to typecast to uint64 in that case.
see: https://github.com/golang/go/blob/c9fb4eb0a22131cc9922fa96afba01d4e21d4fd4/src/syscall/ztypes_linux_mips.go#L104

Fixes #76 