### PR TITLE
Add uid,huid descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ The ps library is compatible with all AIX format descriptors of the ps command-l
   - The corresponding host PID of a container process.
 - **huser**
   - The corresponding effective user of a container process on the host.
+- **huid**
+  - The corresponding host UID of a container process.
 - **label**
   - Current security attributes of the process.
 - **seccomp**

--- a/test/format.bats
+++ b/test/format.bats
@@ -59,6 +59,12 @@
 	[[ ${lines[0]} =~ "USER" ]]
 }
 
+@test "UID header" {
+	run ./bin/psgo -format "uid"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "UID" ]]
+}
+
 @test "COMMAND (args) header" {
 	run ./bin/psgo -format "%a"
 	[ "$status" -eq 0 ]
@@ -211,6 +217,14 @@
 	[[ ${lines[1]} =~ "?" ]]
 }
 
+@test "HUID header" {
+	run ./bin/psgo -format "huid"
+	[ "$status" -eq 0 ]
+	[[ ${lines[0]} =~ "HUID" ]]
+	# host UIDs are only extracted with `-pid`
+	[[ ${lines[1]} =~ "?" ]]
+}
+
 @test "HGROUP header" {
 	run ./bin/psgo -format "hgroup"
 	[ "$status" -eq 0 ]
@@ -265,7 +279,7 @@ function is_labeling_enabled() {
 }
 
 @test "ALL header" {
-	run ./bin/psgo -format "pcpu, group, groups, ppid, user, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capamb, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, hgroup, hgroups, rss, state"
+	run ./bin/psgo -format "pcpu, group, groups, ppid, user, uid, args, comm, rgroup, nice, pid, pgid, etime, ruser, time, tty, vsz, capamb, capinh, capprm, capeff, capbnd, seccomp, hpid, huser, huid, hgroup, hgroups, rss, state"
 	[ "$status" -eq 0 ]
 
 	[[ ${lines[0]} =~ "%CPU" ]]
@@ -273,6 +287,7 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "GROUPS" ]]
 	[[ ${lines[0]} =~ "PPID" ]]
 	[[ ${lines[0]} =~ "USER" ]]
+	[[ ${lines[0]} =~ "UID" ]]
 	[[ ${lines[0]} =~ "COMMAND" ]]
 	[[ ${lines[0]} =~ "COMMAND" ]]
 	[[ ${lines[0]} =~ "RGROUP" ]]
@@ -291,6 +306,7 @@ function is_labeling_enabled() {
 	[[ ${lines[0]} =~ "SECCOMP" ]]
 	[[ ${lines[0]} =~ "HPID" ]]
 	[[ ${lines[0]} =~ "HUSER" ]]
+	[[ ${lines[0]} =~ "HUID" ]]
 	[[ ${lines[0]} =~ "HGROUP" ]]
 	[[ ${lines[0]} =~ "HGROUPS" ]]
 	[[ ${lines[0]} =~ "RSS" ]]

--- a/test/list.bats
+++ b/test/list.bats
@@ -3,5 +3,5 @@
 @test "List descriptors" {
 	run ./bin/psgo -list
 	[ "$status" -eq 0 ]
-	[[ ${lines[0]} =~ "args, capamb, capbnd, capeff, capinh, capprm, comm, etime, group, groups, hgroup, hgroups, hpid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, rss, ruser, seccomp, state, stime, time, tty, user, vsz" ]]
+	[[ ${lines[0]} =~ "args, capamb, capbnd, capeff, capinh, capprm, comm, etime, group, groups, hgroup, hgroups, hpid, huid, huser, label, nice, pcpu, pgid, pid, ppid, rgroup, rss, ruser, seccomp, state, stime, time, tty, uid, user, vsz" ]]
 }


### PR DESCRIPTION
Add two descriptors:
- `uid` prints the effective UID of the process as the decimal representation
- `huid` prints the corresponding host UID of a container process

Example:
```
$ ./bin/podman top 67 pid,hpid,user,uid,huid
PID         HPID        USER        UID         HUID
1           5155        root        0           1000
```

Closes: [#16009](https://github.com/containers/podman/issues/16009)

Signed-off-by: Piotr Resztak <piotr.resztak@gmail.com>

@rhatdan @vrothberg 