### PR TITLE
Add support for `Seccomp_filters` proc status field

### DIFF
--- a/internal/proc/status.go
+++ b/internal/proc/status.go
@@ -156,6 +156,9 @@ type Status struct {
 	// provided only if the kernel was built with the CONFIG_SECCOMP kernel
 	// configu- ration option enabled.
 	Seccomp string
+	// SeccompFilters: Amount of filters attached to the process.
+	// (since Linux 5.9)
+	SeccompFilters string
 	// Cpus_allowed:  Mask  of  CPUs  on  which  this process may run
 	// (since Linux 2.6.24, see cpuset(7)).
 	CpusAllowed string
@@ -379,6 +382,8 @@ func parseStatus(pid string, lines []string) (*Status, error) {
 			s.NoNewPrivs = fields[1]
 		case "Seccomp:":
 			s.Seccomp = fields[1]
+		case "Seccomp_filters:":
+			s.SeccompFilters = fields[1]
 		case "Cpus_allowed:":
 			s.CpusAllowed = fields[1]
 		case "Cpus_allowed_list:":

--- a/internal/proc/status_test.go
+++ b/internal/proc/status_test.go
@@ -70,6 +70,7 @@ CapBnd: ffffffffffffffff
 CapAmb:   0000000000000000
 NoNewPrivs:     0
 Seccomp:        0
+Seccomp_filters:        0
 Cpus_allowed:   00000001
 Cpus_allowed_list:      0
 Mems_allowed:   1
@@ -128,6 +129,7 @@ func TestParseStatus(t *testing.T) {
 	assert.Equal(t, "0000000000000000", s.CapAmb)
 	assert.Equal(t, "0", s.NoNewPrivs)
 	assert.Equal(t, "0", s.Seccomp)
+	assert.Equal(t, "0", s.SeccompFilters)
 	assert.Equal(t, "00000001", s.CpusAllowed)
 	assert.Equal(t, "0", s.CpusAllowedList)
 	assert.Equal(t, "1", s.MemsAllowed)


### PR DESCRIPTION
The field has been added in https://github.com/torvalds/linux/commit/c818c03b661cd769e035e41673d5543ba2ebda64 and is now being parsed correctly.