### PR TITLE
psgo: handle ESRCH as ENOENT

### DIFF
--- a/internal/proc/attr.go
+++ b/internal/proc/attr.go
@@ -15,10 +15,13 @@
 package proc
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // ParseAttrCurrent returns the contents of /proc/$pid/attr/current of "?" if
@@ -27,7 +30,7 @@ func ParseAttrCurrent(pid string) (string, error) {
 	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%s/attr/current", pid))
 	if err != nil {
 		_, err = os.Stat(fmt.Sprintf("/proc/%s", pid))
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH) {
 			// PID doesn't exist
 			return "", err
 		}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containers/psgo/internal/host"
 	"github.com/containers/psgo/internal/proc"
 	"github.com/opencontainers/runc/libcontainer/user"
+	"golang.org/x/sys/unix"
 )
 
 // Process includes process-related from the /proc FS.
@@ -108,7 +109,7 @@ func FromPIDs(pids []string, joinUserNS bool) ([]*Process, error) {
 	for _, pid := range pids {
 		p, err := New(pid, joinUserNS)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH) {
 				// proc parsing is racy
 				// Let's ignore "does not exist" errors
 				continue

--- a/psgo.go
+++ b/psgo.go
@@ -477,7 +477,7 @@ func JoinNamespaceAndProcessInfoByPidsWithOptions(pids []string, descriptors []s
 	for _, pid := range pids {
 		ns, err := proc.ParsePIDNamespace(pid)
 		if err != nil {
-			if errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH) {
 				// catch race conditions
 				continue
 			}
@@ -492,7 +492,7 @@ func JoinNamespaceAndProcessInfoByPidsWithOptions(pids []string, descriptors []s
 	data := [][]string{}
 	for i, pid := range pidList {
 		pidData, err := JoinNamespaceAndProcessInfoWithOptions(pid, descriptors, options)
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ESRCH) {
 			// catch race conditions
 			continue
 		}


### PR DESCRIPTION
for /proc/$PID/cmdline, the kernel could return ESRCH instead of ENOENT if the target process is terminated between the opening of the "cmdline" file and reading from it.

Handle ESRCH in the same way as ENOENT when reading from the proc file system.